### PR TITLE
Updated for AFrame 0.5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ require('./lib/terrainloader.js');
 AFRAME.registerComponent('terrain-model', {
   schema: {
     DEM: {
-      type: 'src'
+      type: 'asset'
     },
     texture: {
-      type: 'src'
+      type: 'asset'
     },
     planeHeight: {
       type: 'number'


### PR DESCRIPTION
Silence warnings about "src" by changing to "asset". Hopefully 100% backwards compatibility...